### PR TITLE
Deactivate the UICC after deactivating the LTE modem 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf-modem-nal"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl Modem {
                 nrfxlib::at::send_at_command("AT+CEPPI=1", |_| {})?;
                 // Set Power Saving Mode (PSM)
                 nrfxlib::at::send_at_command("AT+CPSMS=1", |_| {})?;
-                // Activate LTE without changing GNSS
+                // Activate LTE without changing GNSS, this also activates UICC
                 nrfxlib::at::send_at_command("AT+CFUN=21", |_| {})?;
             }
             // Turning off
@@ -64,6 +64,8 @@ impl Modem {
                 log::debug!("Turning off modem lte");
                 // Deactivate LTE without changing GNSS
                 nrfxlib::at::send_at_command("AT+CFUN=20", |_| {})?;
+                // Deactivate UICC (Universal Integrated Circuit Card) 
+                nrfxlib::at::send_at_command("AT+CFUN=40", |_| {})?;                
             }
             // Staying turned on
             (_, _) => {}


### PR DESCRIPTION
Added AT command to deactivate the UICC (the sim card) after the modem has been turned off.

The [notes section]( https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/cfun_set.html ) of the CFUN command states that the UICC is automatically enabled when the modem is activated (using CFUN=21), but the UICC is not automatically disabled when the modem is deactivated (using CFUN=20). This pull request sends the additional CFUN=40 after the LTE modem is disabled (using CFUN=20) to turn the UICC off. 